### PR TITLE
fix(crawl): retry transient connection timeouts during registry sweeps

### DIFF
--- a/src/malwar/crawl/client.py
+++ b/src/malwar/crawl/client.py
@@ -18,6 +18,10 @@ logger = logging.getLogger("malwar.crawl.client")
 
 BASE_URL = "https://clawhub.ai/api/v1"
 _TIMEOUT = 15.0
+# Transient connection failures (ConnectTimeout/ConnectError) are common when
+# sweeping thousands of skills from CI; retry them at the transport level so a
+# single blip does not abort a long registry crawl.
+_RETRIES = 3
 _USER_AGENT = f"malwar/{__version__}"
 
 
@@ -76,13 +80,18 @@ class ClawHubClient:
         self,
         base_url: str = BASE_URL,
         timeout: float = _TIMEOUT,
+        retries: int = _RETRIES,
     ) -> None:
         self.base_url = base_url.rstrip("/")
         self.timeout = timeout
+        self.retries = retries
 
     def _client(self) -> httpx.AsyncClient:
+        # AsyncHTTPTransport retries connection-level failures — ConnectError
+        # and ConnectTimeout (a subclass) — with exponential backoff.
         return httpx.AsyncClient(
             timeout=httpx.Timeout(self.timeout),
+            transport=httpx.AsyncHTTPTransport(retries=self.retries),
             headers={"User-Agent": _USER_AGENT},
         )
 

--- a/src/malwar/monitor/snapshot.py
+++ b/src/malwar/monitor/snapshot.py
@@ -26,7 +26,7 @@ import logging
 from collections.abc import Callable
 from pathlib import Path
 
-from malwar.crawl.client import ClawHubClient, ClawHubError
+from malwar.crawl.client import ClawHubClient
 from malwar.monitor.models import RegistrySnapshot, SkillRecord
 from malwar.sdk import scan
 
@@ -65,7 +65,7 @@ async def _enumerate_skills(
     while True:
         try:
             items, cursor = await client.list_skills(limit=page_size, cursor=cursor)
-        except ClawHubError as exc:
+        except Exception as exc:  # ClawHubError, httpx timeouts after retries, etc.
             logger.warning("list_skills failed: %s", exc)
             break
         for item in items:
@@ -85,7 +85,7 @@ async def _enumerate_skills(
     for term in _SEED_TERMS:
         try:
             results = await client.search(term, limit=page_size)
-        except ClawHubError as exc:
+        except Exception as exc:  # ClawHubError, httpx timeouts after retries, etc.
             logger.warning("search %r failed: %s", term, exc)
             continue
         for r in results:

--- a/tests/unit/crawl/test_client.py
+++ b/tests/unit/crawl/test_client.py
@@ -266,3 +266,18 @@ class TestFetchUrl:
         with patch("malwar.crawl.client.httpx.AsyncClient", return_value=mc), \
              pytest.raises(ClawHubError):
             await fetch_url("https://example.com/missing.md")
+
+
+class TestConnectionResilience:
+    """The client retries transient connection failures at the transport level."""
+
+    def test_defaults_to_retrying_transport(self):
+        client = ClawHubClient()
+        assert client.retries == 3
+        # _client() wires the retrying transport without error.
+        real = client._client()
+        assert isinstance(real, httpx.AsyncClient)
+
+    def test_retries_configurable(self):
+        assert ClawHubClient(retries=0).retries == 0
+        assert ClawHubClient(retries=5).retries == 5

--- a/tests/unit/test_monitor.py
+++ b/tests/unit/test_monitor.py
@@ -142,6 +142,18 @@ class TestBuildSnapshot:
         assert snap.skills["good"].verdict == "CLEAN"
         assert snap.skills["bad"].error is not None
 
+    async def test_enumeration_timeout_does_not_crash(self):
+        # A raw timeout while listing the registry must not abort the run.
+        client = FakeClawHubClient({"a": BENIGN_BODY})
+
+        async def _boom(limit=20, cursor=None):
+            raise TimeoutError("connect timeout")
+
+        client.list_skills = _boom  # type: ignore[assignment]
+        # search fallback returns [] in the fake → empty snapshot, no exception.
+        snap = await build_snapshot(client, escalate=False)
+        assert snap.skill_count == 0
+
 
 class TestIncrementalSweep:
     async def test_unchanged_skills_are_not_refetched(self):


### PR DESCRIPTION
## Description

All three `Registry Monitor` runs died on `httpx.ConnectTimeout`. Root cause: the `ClawHubClient` created a fresh `AsyncClient` per request with **no retries**, so a single transient connection blip — whether during registry enumeration (list paging) or a per-skill fetch — propagated and aborted the entire crawl. The per-skill guard I added earlier didn't help when the timeout hit `list_skills` during enumeration.

**Fix at the source:**
- `ClawHubClient` now uses `httpx.AsyncHTTPTransport(retries=3)`, which retries connection-level failures (`ConnectError`/`ConnectTimeout`, with backoff) transparently. Retry count is configurable.
- `_enumerate_skills` now degrades gracefully on any residual error after retries (not just `ClawHubError`), so a genuine hard failure stops paging instead of crashing the run.

This is the piece that was actually breaking the live sweeps — the incremental/`--full` logic from #16 is correct; it just never got to run to completion because enumeration kept timing out.

## Type of Change

- [x] Bug fix

## Checklist

- [x] Tests added (client retry config; enumeration surviving a raw timeout) — 1588 pass, 16 skipped
- [x] `ruff` + `mypy` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DNoTXU8k3pfSBzR7aJubqL

---
_Generated by [Claude Code](https://claude.ai/code/session_01DNoTXU8k3pfSBzR7aJubqL)_