### PR TITLE
ci(monitor): run scheduled sweep rules-only so it reliably completes

### DIFF
--- a/.github/workflows/registry-monitor.yml
+++ b/.github/workflows/registry-monitor.yml
@@ -4,11 +4,16 @@
 # the `registry-snapshots` branch so `git log -p registry-snapshots` is a
 # permanent, auditable record of what changed day over day.
 #
+# Scans with the rule engine + threat intel only (no per-skill LLM calls) so a
+# whole-registry sweep is fast and cheap; the rule engine alone catches 100% of
+# malicious samples in the benchmark. Use `malwar crawl scan <slug>` for an LLM
+# deep-dive on an individual flagged skill.
+#
 # Two cadences:
 #   * Daily (06:00 UTC) — INCREMENTAL. Only skills whose version/updated_at
-#     changed since the last snapshot are re-fetched, re-scanned, and (if
-#     flagged) escalated to the LLM. The first run scans everything; every run
-#     after is cheap and fast.
+#     changed since the last snapshot are re-fetched and re-scanned. The first
+#     runs build the baseline (see --max-scans below); after that each run is
+#     cheap and fast.
 #   * Weekly (Sunday 07:00 UTC) — FULL (`--full`). Re-scans every skill to catch
 #     silent same-version content swaps (trojanized updates that keep the same
 #     version number), which incremental detection would otherwise miss.
@@ -17,11 +22,6 @@
 # checks), so a scheduled bot cannot push to it. The snapshot history therefore
 # lives on its own long-running `registry-snapshots` branch, created
 # automatically on the first run.
-#
-# The LLM escalation needs an Anthropic API key. Add it as a *repository* secret
-# named MALWAR_ANTHROPIC_API_KEY (Settings -> Secrets and variables -> Actions ->
-# New repository secret). Without it the sweep still runs on the rule engine +
-# threat intel; only the LLM second opinion on flagged skills is skipped.
 
 name: Registry Monitor
 
@@ -97,15 +97,23 @@ jobs:
           else
             echo "Mode: incremental (only changed skills)."
           fi
-          # ClawHub is rate-limited (~2 req/s), so a full ~6k-skill registry
-          # can't be swept in one CI run. Cap scans per run; the overflow is
-          # deferred and picked up on subsequent runs, so the baseline builds
-          # up over a few days and then daily runs only touch what changed.
+          # Rules + threat-intel only (--no-escalate): the rule engine alone
+          # detects 100% of malicious samples in the benchmark, and skipping
+          # per-skill LLM calls keeps a whole-registry sweep fast and cheap.
+          # (Run `malwar crawl scan <slug>` for an LLM deep-dive on any one
+          # flagged skill.)
+          #
+          # ClawHub is rate-limited (~2 req/s), so even so a full ~6k-skill
+          # registry can't be swept in one CI run. Cap scans per run; the
+          # overflow is deferred and picked up on subsequent runs, so the
+          # baseline builds up over a couple of runs and then daily runs only
+          # touch what changed.
           malwar crawl monitor \
             --snapshot-dir data/registry-snapshots \
             --format json \
             --output data/registry-snapshots/latest-diff.json \
-            --max-scans 1500 \
+            --no-escalate \
+            --max-scans 3000 \
             $FULL
 
       - name: Publish snapshot to data branch

--- a/docs/crawl.md
+++ b/docs/crawl.md
@@ -116,7 +116,7 @@ malwar crawl monitor --max 100 --no-escalate   # quick partial run, rules only
 
 **Options:** `--snapshot-dir`, `--full`, `--max-scans`, `--max`, `--no-escalate`, `--concurrency`, `--format`/`-f` (`console`|`json`), `--output`/`-o`, `--no-save`, `--digest`, `--publish`, `--fail-on-malicious`. Publishing to X requires the `MALWAR_X_*` credentials (see [Configuration](deployment/configuration.md#x-twitter-publishing)).
 
-The bundled GitHub Actions workflow (`.github/workflows/registry-monitor.yml`) runs this on two cadences: **daily incremental** and a **weekly `--full`** re-scan, committing each snapshot to the `registry-snapshots` branch.
+The bundled GitHub Actions workflow (`.github/workflows/registry-monitor.yml`) runs this on two cadences: **daily incremental** and a **weekly `--full`** re-scan, committing each snapshot to the `registry-snapshots` branch. It runs **rules-only (`--no-escalate`)** so a whole-registry sweep stays fast and cheap — the rule engine alone catches every malicious sample in the benchmark; use `malwar crawl scan <slug>` for an LLM deep-dive on an individual flagged skill.
 
 ---
 


### PR DESCRIPTION
## Description

Every scheduled run kept timing out — and with the resumable/budgeted machinery in place, the remaining cause is now clearly **LLM escalation at registry scale**, not the crawl. The registry is malware-dense (~20% flagged), so a large fraction of each batch triggers per-skill LLM calls (several seconds each), pushing runs past the 60-min limit before they can commit — and burning tokens every run.

**Fix:** run the automated sweep with `--no-escalate` (rule engine + threat intel only), and raise `--max-scans` to 3000 (rules-only is fetch-bound at ~2 req/s, so a bigger batch still fits).

**Why this is safe:** the accuracy report shows the **rule engine alone detects 100% of malicious samples with zero false positives** — the LLM adds verdict *confidence*, not additional catches. So automated coverage is unchanged; the sweep is now reliable and near-free, and the ~6k baseline converges in ~2 runs.

The LLM stays available for targeted `malwar crawl scan <slug>` deep-dives on any individual flagged skill. Re-enabling automated escalation (or adding a weekly LLM pass over just the already-flagged set) is a one-line change if wanted later.

Workflow + docs only — no code change.

## Type of Change

- [x] Infrastructure / CI (reliability)

## Checklist

- [x] Workflow YAML validated
- [x] Docs updated (`docs/crawl.md`)
- [x] No application code changed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DNoTXU8k3pfSBzR7aJubqL

---
_Generated by [Claude Code](https://claude.ai/code/session_01DNoTXU8k3pfSBzR7aJubqL)_