### PR TITLE
ci(monitor): bump scan budget + enable Anthropic deep-dive on the ambiguous band

### DIFF
--- a/.github/workflows/registry-monitor.yml
+++ b/.github/workflows/registry-monitor.yml
@@ -4,10 +4,11 @@
 # the `registry-snapshots` branch so `git log -p registry-snapshots` is a
 # permanent, auditable record of what changed day over day.
 #
-# Scans with the rule engine + threat intel only (no per-skill LLM calls) so a
-# whole-registry sweep is fast and cheap; the rule engine alone catches 100% of
-# malicious samples in the benchmark. Use `malwar crawl scan <slug>` for an LLM
-# deep-dive on an individual flagged skill.
+# Scans the whole registry with the rule engine + threat intel (fast, free, 100%
+# recall on the benchmark), and escalates ONLY the ambiguous band — skills the
+# rules flagged short of a confident verdict — to the Anthropic LLM for a
+# budget-capped deep-dive second opinion. Confident-clean and confident-malicious
+# skills are never escalated, so LLM spend tracks the small uncertain middle.
 #
 # Two cadences:
 #   * Daily (06:00 UTC) — INCREMENTAL. Only skills whose version/updated_at
@@ -97,23 +98,27 @@ jobs:
           else
             echo "Mode: incremental (only changed skills)."
           fi
-          # Rules + threat-intel only (--no-escalate): the rule engine alone
-          # detects 100% of malicious samples in the benchmark, and skipping
-          # per-skill LLM calls keeps a whole-registry sweep fast and cheap.
-          # (Run `malwar crawl scan <slug>` for an LLM deep-dive on any one
-          # flagged skill.)
+          # The whole-registry sweep runs the rule engine + threat intel (fast,
+          # free, 100% recall on the benchmark). Only the AMBIGUOUS band — skills
+          # the rules flagged short of a confident verdict — is escalated to the
+          # Anthropic LLM for a deep-dive second opinion (which can raise a sneaky
+          # skill or clear a false positive). Confident-clean and confident-
+          # malicious skills are never escalated, and --escalate-budget caps the
+          # per-run LLM spend. The free local HF classifier tier is available for
+          # local runs (`--escalate-backend hf|tiered`, needs the [hf] extra) but
+          # is kept out of CI to avoid a heavy torch install on the critical path.
           #
-          # ClawHub is rate-limited (~2 req/s), so even so a full ~6k-skill
-          # registry can't be swept in one CI run. Cap scans per run; the
-          # overflow is deferred and picked up on subsequent runs, so the
-          # baseline builds up over a couple of runs and then daily runs only
-          # touch what changed.
+          # ClawHub is rate-limited (~2 req/s) and the registry is ~66k skills, so
+          # a full sweep can't run in one CI window. --max-scans caps scans per
+          # run; the overflow is deferred and picked up next run, so the baseline
+          # builds up over successive runs, then daily runs only touch what changed.
           malwar crawl monitor \
             --snapshot-dir data/registry-snapshots \
             --format json \
             --output data/registry-snapshots/latest-diff.json \
-            --no-escalate \
-            --max-scans 3000 \
+            --escalate-backend anthropic \
+            --escalate-budget 200 \
+            --max-scans 4000 \
             $FULL
 
       - name: Publish snapshot to data branch

--- a/docs/crawl.md
+++ b/docs/crawl.md
@@ -129,7 +129,7 @@ malwar crawl monitor --fail-on-malicious      # exit non-zero when newly-flagged
 
 **Options:** `--snapshot-dir`, `--full`, `--max-scans`, `--max`, `--escalate-backend` (`none`|`hf`|`anthropic`|`tiered`), `--escalate-budget`, `--no-escalate`, `--concurrency`, `--format`/`-f` (`console`|`json`), `--output`/`-o`, `--no-save`, `--digest`, `--publish`, `--fail-on-malicious`. Publishing to X requires the `MALWAR_X_*` credentials (see [Configuration](deployment/configuration.md#x-twitter-publishing)).
 
-The bundled GitHub Actions workflow (`.github/workflows/registry-monitor.yml`) runs this on two cadences: **daily incremental** and a **weekly `--full`** re-scan, committing each snapshot to the `registry-snapshots` branch. It runs **rules-only (`--no-escalate`)** so a whole-registry sweep stays fast and cheap — the rule engine alone catches every malicious sample in the benchmark; use `malwar crawl scan <slug>` for an LLM deep-dive on an individual flagged skill.
+The bundled GitHub Actions workflow (`.github/workflows/registry-monitor.yml`) runs this on two cadences — **daily incremental** and a **weekly `--full`** re-scan — committing each snapshot to the `registry-snapshots` branch. The whole-registry sweep is rules + threat-intel; only the **ambiguous band** is escalated to the **Anthropic** LLM (`--escalate-backend anthropic --escalate-budget 200`), so LLM spend tracks the small uncertain middle, not the whole registry. The free local HF tier (`--escalate-backend hf|tiered`) is kept out of CI to avoid a heavy `torch` install on the critical path — use it for local runs.
 
 ---
 

--- a/src/malwar/monitor/escalation.py
+++ b/src/malwar/monitor/escalation.py
@@ -142,7 +142,10 @@ class AnthropicBackend:
     async def assess(self, content: str, *, file_name: str) -> EscalationResult:
         from malwar.sdk import scan
 
-        result = await scan(content, file_name=file_name, use_llm=True, use_urls=True)
+        # LLM semantic analysis + rules + threat intel. Live URL crawling is
+        # left off: it adds latency and external-fetch flakiness at escalation
+        # scale, and the deep dive's value here is the LLM's read of intent.
+        result = await scan(content, file_name=file_name, use_llm=True, use_urls=False)
         return EscalationResult(
             backend=self.name,
             flagged=result.verdict != "CLEAN",

--- a/tests/unit/test_escalation.py
+++ b/tests/unit/test_escalation.py
@@ -197,7 +197,7 @@ class TestAnthropicBackend:
             risk_score = 55
 
         async def fake_scan(content, *, file_name, use_llm, use_urls):
-            assert use_llm and use_urls
+            assert use_llm and not use_urls  # LLM on, live URL crawl off
             return _Result()
 
         monkeypatch.setattr("malwar.sdk.scan", fake_scan)


### PR DESCRIPTION
## Description

Turns on targeted escalation in the scheduled sweep now that the pipeline reliably commits, and validates the HF model.

- **Budget bump:** `--max-scans` 3000 → **4000** (rules-only is fetch-bound at ~2 req/s; 4000 still fits the CI window and shortens the ~66k-skill baseline build).
- **Anthropic deep-dive on the outliers:** `--escalate-backend anthropic --escalate-budget 200`. The ~150 skills/run the rules flag *short of a confident verdict* (the ambiguous band — SUSPICIOUS/CAUTION) get an LLM second opinion that can raise a sneaky skill or clear a false positive. Confident-clean and confident-malicious are never escalated, so LLM spend tracks the small uncertain middle — not the whole 66k registry.
- **Escalation no longer live-crawls URLs** (`use_urls` off in `AnthropicBackend`): removes external-fetch latency/flakiness at escalation scale; the deep dive's value is the LLM's read of intent (rules + threat intel still run).

### HF model — validated ✅
Confirmed on the Hub: **`protectai/deberta-v3-base-prompt-injection-v2`** — apache-2.0, **ungated**, 5.6M downloads, ships ONNX weights. That's the right free-tier pick (permissive license, no HF token needed). It stays wired as the default for local `--escalate-backend hf|tiered`, but is **kept out of CI** to avoid a ~2GB `torch` install on the run that must reliably commit. Enabling it in CI (or a decoupled escalation job) is a follow-up if we want the free tier automated.

### Why Anthropic-direct rather than tiered-in-CI
The ambiguous band is only ~150 skills/run, so Anthropic's cost is already small; putting HF (torch) in the daily job would add fragility to the pipeline we just got committing, for marginal savings. Anthropic-direct is the reliable "deep dive on the outliers."

## Type of Change

- [x] Infrastructure / CI
- [x] Minor behavior change (escalation URL crawl off)

## Checklist

- [x] Workflow YAML validated; `ruff` + tests pass (65 monitor/escalation)
- [x] HF model verified on the Hub (license, gating, downloads)
- [x] Docs updated (`docs/crawl.md`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DNoTXU8k3pfSBzR7aJubqL

---
_Generated by [Claude Code](https://claude.ai/code/session_01DNoTXU8k3pfSBzR7aJubqL)_