### PR TITLE
fix(ci): monitor publish step fails once the data branch exists

### DIFF
--- a/.github/workflows/registry-monitor.yml
+++ b/.github/workflows/registry-monitor.yml
@@ -126,9 +126,14 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
 
-          # Preserve the freshly generated snapshot files across the branch switch.
+          # Save the freshly generated snapshot files, then clear them from the
+          # working tree. Once the data branch exists, `git checkout` refuses to
+          # switch when untracked files here would be overwritten by the branch's
+          # tracked versions — so we stash to $tmp and remove them first, then
+          # overlay them back after the switch.
           tmp="$(mktemp -d)"
           cp -a data/registry-snapshots/. "$tmp/"
+          rm -rf data/registry-snapshots
 
           # Move onto the data branch (create an orphan branch on the first run).
           if git rev-parse --verify origin/registry-snapshots >/dev/null 2>&1; then


### PR DESCRIPTION
## Description

The last two scheduled sweeps (runs #8, #9) **ran the full scan + escalation successfully but failed at the commit step** — so their results were thrown away. That's why chunk 2 never landed on `registry-snapshots`.

Cause: `git checkout -B registry-snapshots origin/registry-snapshots` aborts with *"untracked working tree files would be overwritten by checkout"* — the freshly generated `latest.json` / `snapshot-*.json` sit untracked in `data/registry-snapshots/` and collide with the branch's tracked versions. The **first** run escaped this because the branch didn't exist yet (orphan-branch path, nothing to collide with), so the bug only shows up from the second run onward.

Fix: after copying the fresh files to `$tmp`, `rm -rf data/registry-snapshots` before the checkout so nothing blocks the switch, then overlay them back.

## Type of Change

- [x] Bug fix (CI)

## Checklist

- [x] Workflow YAML validated
- [x] One-line change to the publish step; scan/escalation logic untouched

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DNoTXU8k3pfSBzR7aJubqL

---
_Generated by [Claude Code](https://claude.ai/code/session_01DNoTXU8k3pfSBzR7aJubqL)_